### PR TITLE
SPIKE install library on ubuntu (required by wkhtmltoimage)

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,77 @@
+# Workflow to run RSpec tests
+#  This uses a postgres db with the sv_SE locale.
+#
+# TODO: use variables to get user ids, passwords, database names, etc.
+# TODO: install imagemagick so that wkhtmltoimage can run
+
+name: rspec
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  tests:
+    name: RSpec tests
+    runs-on: ubuntu-18.04
+
+
+    env:
+      RAILS_ENV: test
+      GEMFILE_RUBY_VERSION: 2.7.2
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: password
+
+
+    services:
+      postgres:
+        # This image (from hub.docker.com) already has the sv_SE locale and collation set up.
+        # It is based on postgres:11
+        image: ashleyengelund/postgres-sv-se:postgres11-sv_se
+
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: shf_project_test
+
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install wkthtmltopdf
+        run: |
+          sudo apt-get install xvfb libfontconfig wkhtmltopdf
+#          sudo apt-get install -y xfonts-base xfonts-75dpi
+#          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
+#          sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
+
+
+      - name: Connect to and set up the test database
+        env:
+          RAILS_ENV: test
+
+        run: |
+          bundle exec bin/rails db:create db:migrate
+          bundle exec bin/rails db:schema:dump
+          bundle exec bin/rails db:test:prepare
+
+
+      - name: Run tests
+        run: bin/rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       RAILS_ENV: test
-      GEMFILE_RUBY_VERSION: 2.7.2
+      GEMFILE_RUBY_VERSION: 2.6.6
       PGHOST: localhost
       PGUSER: postgres
       PGPASSWORD: password
@@ -50,14 +50,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Write access so wkhtmltopdf_binary_gem can unzip the binaries it needs
+      - run: |
+          sudo chmod -R 777 /usr/lib/ruby/versions/2.7/lib/ruby/gems/2.7.0/gems/wkhtmltopdf-binary-0.12.5.1/bin/
+
+
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - name: Install wkthtmltopdf
-        run: |
-          sudo apt-get install xvfb libfontconfig wkhtmltopdf
+#      - name: Install wkthtmltopdf
+#        run: |
+          sudo apt-get install wkhtmltopdf
 #          sudo apt-get install -y xfonts-base xfonts-75dpi
 #          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
 #          sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
@@ -73,5 +78,6 @@ jobs:
           bundle exec bin/rails db:test:prepare
 
 
-      - name: Run tests
-        run: bin/rspec
+      - name: Run only the tests that use wkhtmltopdf
+        run: bundle exec bin/rspec spec/controllers/users_controller_spec.rb
+

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,31 +20,32 @@ env:
 
 
 jobs:
+
   tests:
     name: RSpec tests
     runs-on: ubuntu-18.04
 
-    services:
-      postgres:
-        # This image (from hub.docker.com) already has the sv_SE locale and collation set up.
-        # It is based on postgres:11
-        image: ashleyengelund/postgres-sv-se:postgres11-sv_se
-
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: shf_project_test
-
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+#    services:
+#      postgres:
+#        # This image (from hub.docker.com) already has the sv_SE locale and collation set up.
+#        # It is based on postgres:11
+#        image: ashleyengelund/postgres-sv-se:postgres11-sv_se
+#
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: password
+#          POSTGRES_DB: shf_project_test
+#
+#        ports:
+#          # Maps tcp port 5432 on service container to the host
+#          - 5432:5432
+#
+#        # Set health checks to wait until postgres has started
+#        options: >-
+#          --health-cmd pg_isready
+#          --health-interval 10s
+#          --health-timeout 5s
+#          --health-retries 5
 
 
     steps:
@@ -56,17 +57,19 @@ jobs:
         with:
           bundler-cache: true
 
-#      - name: Run wkthtmltoimage (gem) to install needed executable
-#        run: bundle exec wkhtmltoimage
-
-
-      - name: Connect to and set up the test database
+      - name: Install libpng12.so
         run: |
-          bundle exec bin/rails db:create db:migrate
-          bundle exec bin/rails db:schema:dump
-          bundle exec bin/rails db:test:prepare
-
-
-      - name: Run only the tests that use wkhtmltopdf
-        run: bundle exec bin/rspec spec/controllers/users_controller_spec.rb
+          sudo wget http://se.archive.ubuntu.com/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
+          sudo dpkg -i libpng12-0_1.2.54-1ubuntu1_amd64.deb
+#
+#
+#      - name: Connect to and set up the test database
+#        run: |
+#          bundle exec bin/rails db:create db:migrate
+#          bundle exec bin/rails db:schema:dump
+#          bundle exec bin/rails db:test:prepare
+#
+#
+#      - name: Run only the tests that use wkhtmltopdf
+#        run: bundle exec bin/rspec spec/controllers/users_controller_spec.rb
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,19 +9,20 @@ on:
   workflow_dispatch:
   push:
 
+env:
+  RAILS_ENV: test
+  RUBY_VERSION: 2.6.6
+  GEMFILE_RUBY_VERSION: 2.7.2
+
+  PGHOST: localhost
+  PGUSER: postgres
+  PGPASSWORD: password
+
+
 jobs:
   tests:
     name: RSpec tests
     runs-on: ubuntu-18.04
-
-
-    env:
-      RAILS_ENV: test
-      GEMFILE_RUBY_VERSION: 2.6.6
-      PGHOST: localhost
-      PGUSER: postgres
-      PGPASSWORD: password
-
 
     services:
       postgres:
@@ -50,28 +51,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-#      - name: Write access so wkhtmltopdf_binary_gem can unzip the binaries it needs
-#      - run: |
-#          sudo chmod -R 777 /usr/lib/ruby/versions/2.7/lib/ruby/gems/2.7.0/gems/wkhtmltopdf-binary-0.12.5.1/bin/
-
-
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - name: Install wkthtmltopdf
-        run: |
-          sudo apt-get install wkhtmltopdf
-#          sudo apt-get install -y xfonts-base xfonts-75dpi
-#          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
-#          sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
+#      - name: Run wkthtmltoimage (gem) to install needed executable
+#        run: bundle exec wkhtmltoimage
 
 
       - name: Connect to and set up the test database
-        env:
-          RAILS_ENV: test
-
         run: |
           bundle exec bin/rails db:create db:migrate
           bundle exec bin/rails db:schema:dump

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Write access so wkhtmltopdf_binary_gem can unzip the binaries it needs
-      - run: |
-          sudo chmod -R 777 /usr/lib/ruby/versions/2.7/lib/ruby/gems/2.7.0/gems/wkhtmltopdf-binary-0.12.5.1/bin/
+#      - name: Write access so wkhtmltopdf_binary_gem can unzip the binaries it needs
+#      - run: |
+#          sudo chmod -R 777 /usr/lib/ruby/versions/2.7/lib/ruby/gems/2.7.0/gems/wkhtmltopdf-binary-0.12.5.1/bin/
 
 
       - name: Setup Ruby and install gems
@@ -60,8 +60,8 @@ jobs:
         with:
           bundler-cache: true
 
-#      - name: Install wkthtmltopdf
-#        run: |
+      - name: Install wkthtmltopdf
+        run: |
           sudo apt-get install wkhtmltopdf
 #          sudo apt-get install -y xfonts-base xfonts-75dpi
 #          wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,27 +25,27 @@ jobs:
     name: RSpec tests
     runs-on: ubuntu-18.04
 
-#    services:
-#      postgres:
-#        # This image (from hub.docker.com) already has the sv_SE locale and collation set up.
-#        # It is based on postgres:11
-#        image: ashleyengelund/postgres-sv-se:postgres11-sv_se
-#
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: password
-#          POSTGRES_DB: shf_project_test
-#
-#        ports:
-#          # Maps tcp port 5432 on service container to the host
-#          - 5432:5432
-#
-#        # Set health checks to wait until postgres has started
-#        options: >-
-#          --health-cmd pg_isready
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 5
+    services:
+      postgres:
+        # This image (from hub.docker.com) already has the sv_SE locale and collation set up.
+        # It is based on postgres:11
+        image: ashleyengelund/postgres-sv-se:postgres11-sv_se
+
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: shf_project_test
+
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
 
     steps:
@@ -61,15 +61,15 @@ jobs:
         run: |
           sudo wget http://se.archive.ubuntu.com/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
           sudo dpkg -i libpng12-0_1.2.54-1ubuntu1_amd64.deb
-#
-#
-#      - name: Connect to and set up the test database
-#        run: |
-#          bundle exec bin/rails db:create db:migrate
-#          bundle exec bin/rails db:schema:dump
-#          bundle exec bin/rails db:test:prepare
-#
-#
-#      - name: Run only the tests that use wkhtmltopdf
-#        run: bundle exec bin/rspec spec/controllers/users_controller_spec.rb
+
+
+      - name: Connect to and set up the test database
+        run: |
+          bundle exec bin/rails db:create db:migrate
+          bundle exec bin/rails db:schema:dump
+          bundle exec bin/rails db:test:prepare
+
+
+      - name: Run only the tests that use wkhtmltopdf
+        run: bundle exec bin/rspec spec/controllers/users_controller_spec.rb
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,8 +1,5 @@
 # Workflow to run RSpec tests
 #  This uses a postgres db with the sv_SE locale.
-#
-# TODO: use variables to get user ids, passwords, database names, etc.
-# TODO: install imagemagick so that wkhtmltoimage can run
 
 name: rspec
 on:
@@ -57,7 +54,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Install libpng12.so
+      - name: Install libpng12.so (required by IMGkit / wkhtmltoimage )
         run: |
           sudo wget http://se.archive.ubuntu.com/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
           sudo dpkg -i libpng12-0_1.2.54-1ubuntu1_amd64.deb
@@ -70,6 +67,6 @@ jobs:
           bundle exec bin/rails db:test:prepare
 
 
-      - name: Run only the tests that use wkhtmltopdf
+      - name: Run tests that use wkhtmltoimage
         run: bundle exec bin/rspec spec/controllers/users_controller_spec.rb
 


### PR DESCRIPTION
## PT Story:  SPIKE install imagemagick, etc on Github action
#### PT URL: https://www.pivotaltracker.com/story/show/179787928

Install packages (e.g. imagemagick) in the os